### PR TITLE
Made gitignore ignore all build directories, not just build-pepper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ Release
 bin/win_debug/libqi.pdb
 *.user
 .qi/
-build-pepper/
+build*/
 *.exe
 include/
 packages/


### PR DESCRIPTION
When building in Linux a build-linux-self build directory gets created and git should ignore it.